### PR TITLE
Modify the actual responses (not the loop variable copies)

### DIFF
--- a/sdk/push_client.go
+++ b/sdk/push_client.go
@@ -119,8 +119,8 @@ func (c *PushClient) publishInternal(messages []PushMessage) ([]PushResponse, er
 		return nil, NewPushServerError(errorMessage, resp, r, nil)
 	}
 	// Add the original message to each response for reference
-	for i, receipt := range r.Data {
-		receipt.PushMessage = messages[i]
+	for i := range r.Data {
+		r.Data[i].PushMessage = messages[i]
 	}
 	return r.Data, nil
 }


### PR DESCRIPTION
The original code was modifying the loop variable copies, not the returned responses (i.e. the responses had no original messages set).