### PR TITLE
Add support for multiple recipients

### DIFF
--- a/sdk/push.go
+++ b/sdk/push.go
@@ -52,16 +52,16 @@ const (
 //	ChannelID: ID of the Notification Channel through which to display this
 //         notification on Android devices.
 type PushMessage struct {
-	To         ExponentPushToken `json:"to"`
-	Body       string            `json:"body"`
-	Data       map[string]string `json:"data,omitempty"`
-	Sound      string            `json:"sound,omitempty"`
-	Title      string            `json:"title,omitempty"`
-	TTLSeconds int               `json:"ttl,omitempty"`
-	Expiration int64             `json:"expiration,omitempty"`
-	Priority   string            `json:"priority,omitempty"`
-	Badge      int               `json:"badge,omitempty"`
-	ChannelID  string            `json:"channelId,omitempty"`
+	To         []ExponentPushToken `json:"to"`
+	Body       string              `json:"body"`
+	Data       map[string]string   `json:"data,omitempty"`
+	Sound      string              `json:"sound,omitempty"`
+	Title      string              `json:"title,omitempty"`
+	TTLSeconds int                 `json:"ttl,omitempty"`
+	Expiration int64               `json:"expiration,omitempty"`
+	Priority   string              `json:"priority,omitempty"`
+	Badge      int                 `json:"badge,omitempty"`
+	ChannelID  string              `json:"channelId,omitempty"`
 }
 
 // Response is the HTTP response returned from an Expo publish HTTP request

--- a/sdk/push_client.go
+++ b/sdk/push_client.go
@@ -78,8 +78,13 @@ func (c *PushClient) PublishMultiple(messages []PushMessage) ([]PushResponse, er
 func (c *PushClient) publishInternal(messages []PushMessage) ([]PushResponse, error) {
 	// Validate the messages
 	for _, message := range messages {
-		if message.To == "" {
-			return nil, errors.New("Invalid push token")
+		if len(message.To) == 0 {
+			return nil, errors.New("No recipients")
+		}
+		for _, recipient := range message.To {
+			if recipient == "" {
+				return nil, errors.New("Invalid push token")
+			}
 		}
 	}
 	url := fmt.Sprintf("%s%s/push/send", c.host, c.apiURL)


### PR DESCRIPTION
The Expo documentation [recommends that you use one request to send a push notification to multiple recipients](https://docs.expo.io/guides/push-notifications/?redirected#sending-notifications-from-your-server), so I implemented that functionality.