### PR TITLE
use-fcm-v1 parameter on http request

### DIFF
--- a/sdk/push_client.go
+++ b/sdk/push_client.go
@@ -108,6 +108,10 @@ func (c *PushClient) publishInternal(messages []PushMessage) ([]PushResponse, er
 		return nil, err
 	}
 
+	query := req.URL.Query()
+	query.Add("useFcmV1", "true")
+	req.URL.RawQuery = query.Encode()
+
 	// Add appropriate headers
 	req.Header.Add("Content-Type", "application/json")
 	if c.accessToken != "" {


### PR DESCRIPTION
Since Google has updated its endpoint, we need to add a parameter to the http request called useFcmV1 set to true